### PR TITLE
Auto loading test vectors from distribution directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,26 @@
 # HLS makefile
 
-config_dir = config
-dist_dir = current_dist
-project = hls_impl
-
-hlx = vivado_hls
+manage = python manage.py
 remove = rm -rf
 
 .PHONY: all csim csynth cosim export clean
 
 all: export
 
-$(project): $(dist_dir)
-	$(hlx) $(config_dir)/create_project.tcl
+csim:
+	$(manage) $@
 
-csim: $(project)
-	$(hlx) $(config_dir)/$@.tcl
+csynth:
+	$(manage) $@
 
-csynth: $(project)
-	$(hlx) $(config_dir)/$@.tcl
+cosim:
+	$(manage) $@
 
-cosim: csim csynth
-	$(hlx) $(config_dir)/$@.tcl
-
-export: cosim
-	$(hlx) $(config_dir)/$@.tcl
+export:
+	$(manage) $@
 
 clean:
-	$(remove) $(project)
+	$(manage) $@
 
 distclean: clean
-	$(remove) $(dist_dir)
 	$(remove) *.log

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Creating GTL with High Level Synthesis
     $ git clone https://github.com/herbberg/hls4gtl.git
     $ git checkout <branch/tag>
     $ python manage.py init </path/to/menu/dist> <module_id>
-    $ make
+    $ python manage.py export
 
 The generated symlink ```current_dist``` in the project root directory is the
 entry point for the auto generated HLS source files implementing a menu module.
@@ -15,11 +15,19 @@ The symlink can be configured either manually, by external scripts or by
 using ```manage.py``` which provides also integrity checks on the linked
 distribution directory:
 
-    $ python manage.py init|status|clean [args...]
+    $ python manage.py init|status|reset [...]
 
-Run individual makefile targets:
+To generate a solution, run simulation or export the IP core use the HLS specific comamnds:
 
-    $ make csim|csynth|cosim|export|clean
+    $ python manage.py csim|csynth|cosim|export|clean [...]
+
+### C/Co simulation
+
+Running ```manage.py csim``` or ```manage.py csim``` automatically crawls for test vector files in the menu distribution's ```testvectors``` directory. The search pattern is ```TestVector*.txt```. Every located test vector is loaded by the C/Co simulation.
+
+To run the C simulation with one or more custom test vectors apply them using the ```--testvector <file ...>``` option.
+
+    $ python manage.py csim --testvector custom_testvector.txt
 
 ### HLS directives
 

--- a/config/create_project.tcl
+++ b/config/create_project.tcl
@@ -6,7 +6,7 @@ set_top $top
 add_files src/algos.cpp
 add_files -tb tb/algos_test.cpp
 add_files -tb tb/byte_vector.h
-add_files -tb tb/hex_bytes.h
+add_files -tb tb/bytelify.h
 add_files -tb tb/ostream_utils.cpp
 add_files -tb tb/ostream_utils.h
 add_files -tb tb/test_vector.cpp

--- a/config/create_project.tcl
+++ b/config/create_project.tcl
@@ -4,7 +4,7 @@ delete_project $project
 open_project $project
 set_top $top
 add_files src/algos.cpp
-add_files -tb tb/algos_test_4_c_cosim.cpp
+add_files -tb tb/algos_test.cpp
 add_files -tb tb/byte_vector.h
 add_files -tb tb/hex_bytes.h
 add_files -tb tb/ostream_utils.cpp

--- a/manage.py
+++ b/manage.py
@@ -1,12 +1,26 @@
 #!/usr/bin/env python
 
+from glob import glob
 import argparse
-import glob
 import logging
+import shutil
+import subprocess
 import sys, os
 
-MaxModules = 6
-TargetSymlink = 'current_dist'
+class Default:
+    max_modules = 6
+    current_dist = 'current_dist'
+    vivado_hls = 'vivado_hls'
+    project = 'hls_impl'
+
+class Status:
+    def __init__(self, label, value, style=None):
+        self.label = label
+        self.value = value
+        self.style = style or ''
+        self.hint = ""
+    def __repr__(self):
+        return colorize(self.label, self.style)
 
 def colorize(text, style):
     """Colorize a text using TTY escape sequences.
@@ -30,20 +44,29 @@ def integrity_check(path):
 def locate_testvectors(path):
     """Returns list of found testvectors and number of events."""
     testvectors = []
-    for filename in glob.glob(os.path.join(path, 'TestVector*.txt')):
+    for filename in glob(os.path.join(path, 'TestVector*.txt')):
         with open(filename) as fp:
             events = sum(1 for line in fp)
         testvectors.append((filename, events))
     return testvectors
 
+def cmd_reset(args):
+    """Reset command, removes distribution symlink."""
+    if os.path.islink(args.current_dist):
+        os.unlink(args.current_dist)
+        logging.info("removed symlink %s", args.current_dist)
+    cmd_clean(args)
+
 def cmd_clean(args):
-    """Clear command, removes distribution symlink."""
-    if os.path.islink(TargetSymlink):
-        os.unlink(TargetSymlink)
-        logging.info("removed symlink %s", TargetSymlink)
+    """Clear command, removes project implementation."""
+    if os.path.isdir(Default.project):
+        shutil.rmtree(Default.project)
+        logging.info("removed implementation %s", Default.project)
 
 def cmd_init(args):
     """Init command, creates distribution symlink."""
+    if os.path.islink(args.current_dist):
+        raise RuntimeError("project already initalized")
     src_dir = os.path.join(args.dist, 'hls', 'module_{}'.format(args.module))
     if not os.path.isdir(src_dir):
         raise IOError("no such directory: {}".format(src_dir))
@@ -51,23 +74,25 @@ def cmd_init(args):
         raise IOError("not a valid distribution directory: {}".format(src_dir))
     cmd_clean(args)
     logging.info("create symlink: current_dist -> %s", src_dir)
-    os.symlink(src_dir, TargetSymlink)
-    cmd_status(args)
+    os.symlink(src_dir, args.current_dist)
+    cmd_auto_create_project(args)
 
 def cmd_status(args):
     """Status command, shows integrity status of distribution symlink."""
     dirname = os.path.dirname
     basename = os.path.basename
     write = sys.stdout.write
-    status = ('NOT_CONFIGURED', '1;33')
-    if os.path.islink(TargetSymlink):
-        target_dir = os.readlink(TargetSymlink)
-        status = ('DEAD_SYMLINK', '1;31')
+    status = Status('NOT_CONFIGURED', False, style='1;33')
+    status.hint = "run {} init </path/to/dist> <module_id> to create a '{}' symlink.".format(__file__, args.current_dist)
+    if os.path.islink(args.current_dist):
+        target_dir = os.readlink(args.current_dist)
+        status = Status('DEAD_SYMLINK', False, style='1;31')
+        status.hint = "check the {} symlink.".format(args.current_dist)
         if os.path.exists(target_dir):
-            status = ('INVALID_LOCATION', '1;31')
+            status = Status('INVALID_LOCATION', False, style='1;31')
             if integrity_check(target_dir):
-                status = ('OK', '1;32')
-                write("{}: {}\n".format(TargetSymlink, target_dir))
+                status = Status('OK', True, style='1;32')
+                write("{}: {}\n".format(args.current_dist, target_dir))
                 module = basename(target_dir).split('_')[-1]
                 write("module: {}\n".format(module))
                 menu = basename(dirname(dirname((target_dir))))
@@ -81,19 +106,77 @@ def cmd_status(args):
                 else:
                     write("testvectors: {}\n".format('none'))
     # add some fancy colors
-    write("status: {}\n".format(colorize(*status)))
+    write("status: {} [{}]\n".format(status, status.value))
+    if status.hint:
+        write("hint: {}\n".format(status.hint))
+    return status.value
+
+def cmd_auto_create_project(args):
+    if not os.path.isdir(Default.project):
+        context='config/create_project.tcl'
+        command = [args.vivado_hls, context]
+        subprocess.check_call(command)
+
+def cmd_csim(args):
+    cmd_auto_create_project(args)
+    context='config/csim.tcl'
+    command = [args.vivado_hls, context]
+    subprocess.check_call(command)
+
+def cmd_csynth(args):
+    cmd_auto_create_project(args)
+    context='config/csynth.tcl'
+    command = [args.vivado_hls, context]
+    subprocess.check_call(command)
+
+def cmd_cosim(args):
+    cmd_auto_create_project(args)
+    cmd_csim(args)
+    cmd_csynth(args)
+    context='config/cosim.tcl'
+    command = [args.vivado_hls, context]
+    subprocess.check_call(command)
+
+def cmd_export(args):
+    cmd_auto_create_project(args)
+    cmd_cosim(args)
+    context='config/export.tcl'
+    command = [args.vivado_hls, context]
+    subprocess.check_call(command)
 
 def parse_args():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='command')
+
     init_parser = subparsers.add_parser('init', help="initialize with module distribution")
     init_parser.add_argument('dist', help="menu distribution directory")
-    init_parser.add_argument('module', type=int, help="module ID (0...{})".format(MaxModules-1))
+    init_parser.add_argument('module', type=int, help="module ID (0...{})".format(Default.max_modules-1))
     init_parser.set_defaults(func=cmd_init)
-    clear_parser = subparsers.add_parser('clean', help="remove current module distribution")
+
+    reset_parser = subparsers.add_parser('reset', help="remove current module distribution")
+    reset_parser.set_defaults(func=cmd_reset)
+
+    clear_parser = subparsers.add_parser('clean', help="remove project/solution")
     clear_parser.set_defaults(func=cmd_clean)
+
     status_parser = subparsers.add_parser('status', help="show module distribution")
     status_parser.set_defaults(func=cmd_status)
+
+    csim_parser = subparsers.add_parser('csim', help="run C simulation")
+    csim_parser.set_defaults(func=cmd_csim)
+
+    csynth_parser = subparsers.add_parser('csynth', help="run C synthesis")
+    csynth_parser.set_defaults(func=cmd_csynth)
+
+    cosim_parser = subparsers.add_parser('cosim', help="run co-simulation")
+    cosim_parser.set_defaults(func=cmd_cosim)
+
+    export_parser = subparsers.add_parser('export', help="run export IP core")
+    export_parser.set_defaults(func=cmd_export)
+
+    parser.add_argument('--current-dist', metavar='<dir>', default=Default.current_dist, help="current_dist symlink path, default is '{}'".format(Default.current_dist))
+    parser.add_argument('--vivado-hls', metavar='<exec>', default=Default.vivado_hls, help="Xilinx Vivado HLS executable, default is '{}'".format(Default.vivado_hls))
+
     return parser.parse_args()
 
 def main():

--- a/tb/byte_vector.h
+++ b/tb/byte_vector.h
@@ -1,7 +1,7 @@
 #ifndef tb_byte_vector_h
 #define tb_byte_vector_h
 
-#include "hex_bytes.h"
+#include "bytelify.h"
 
 #include <cassert>
 #include <climits>
@@ -37,7 +37,7 @@ struct byte_vector
     /* Read byte vector from hex string. */
     void from_hex_str(const std::string& s)
     {
-        data = hex_bytes<data_type>(s.cbegin(), s.cend());
+        data = bytelify<data_type>(s.cbegin(), s.cend());
     }
 
     /* Extract bit slice from byte vector. */

--- a/tb/bytelify.h
+++ b/tb/bytelify.h
@@ -1,6 +1,7 @@
-#ifndef tb_hex_bytes_h
-#define tb_hex_bytes_h
+#ifndef tb_bytelify_h
+#define tb_bytelify_h
 
+#include <cstddef>
 #include <iterator>
 #include <string>
 #include <vector>
@@ -9,12 +10,13 @@ namespace tb {
 
 /* Arbitrary hex string to byte vector.
  *
- * std::vector<uint8_t> v = hex_bytes<uint8_t>("deadbeef");
+ * std::string s = "deadbeef";
+ * std::vector<uint8_t> v = bytelify<uint16_t>(s.begin(), s.end());
  * // v = [0xbeef, 0xdead]
  *
  */
-template<typename T>
-std::vector<T> hex_bytes(const std::string::const_iterator& cbegin, const std::string::const_iterator& cend)
+template<typename T = uint8_t>
+std::vector<T> bytelify(const std::string::const_iterator& cbegin, const std::string::const_iterator& cend, size_t base = 16)
 {
     // Width in nibbles depending on type T
     static const size_t width = sizeof(T) * 2;
@@ -39,6 +41,18 @@ std::vector<T> hex_bytes(const std::string::const_iterator& cbegin, const std::s
     }
     return v;
 }
+
+/* Arbitrary hex string to byte vector.
+ *
+ * std::vector<uint8_t> v = bytelify<uint16_t>("deadbeef");
+ * // v = [0xbeef, 0xdead]
+ *
+ */
+ template<typename T = uint8_t>
+ std::vector<T> bytelify(const std::string& s, size_t base = 16)
+ {
+    return bytelify<T>(s.begin(), s.end(), base);
+ }
 
 } //namespace tb
 

--- a/tb/test_vector.cpp
+++ b/tb/test_vector.cpp
@@ -38,7 +38,7 @@ void test_vector::load_bx(std::istream& is)
 
     if (is.fail())
     {
-        throw std::runtime_error("invalid data format");
+        throw std::runtime_error("invalid test vector format");
     }
 
     if (verbose)


### PR DESCRIPTION
C and co simulation loads all test vectors located in the ```testvectors``` directory of the menu distribution. The search pattern is ```TestVector_*.txt```.

    $ python manage.py csim  # loads all test vectors from dist

Use ```manage.py status``` to inspect the available test vectors.

To run with individual test vectors use the ```--testvector <file ...>``` option.

    $ python manage.py csim --testvector custom_testvector.txt

(this disqualifies the Makefile somehow as it can't take individual command line arguments, we can manage.py instead).