### PR TITLE
added utils/math.h

### DIFF
--- a/src/gtl/utils/math.h
+++ b/src/gtl/utils/math.h
@@ -1,0 +1,26 @@
+#ifndef gtl_utils_math_h
+#define gtl_utils_math_h
+
+#include <cstddef>
+
+namespace gtl {
+namespace utils {
+namespace math {
+
+template <size_t A, size_t B>
+struct pow
+{
+    static const size_t value = A * pow<A, B - 1>::value;
+};
+
+template <size_t A>
+struct pow<A, 0>
+{
+    static const size_t value = 1;
+};
+
+} // namespace math
+} // namespace utils
+} // namespace gtl
+
+#endif


### PR DESCRIPTION
Providing pre-processor pow() meta programming template.

Usage example:

```
#include "gtl/utils/math.h"

using namespace gtl::utils;

const size_t VALUE = math::pow<2, 8>::value;
```
Future plans/thoughts: move everything into `gtl` namspace, eg.
* `gtl::object::jet` ... `src/gtl/object/jet.h`
* `gtl::req::jet` ... `src/gtl/req/jet.h`
* etc.